### PR TITLE
Move background variables to constants.js

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-      <BackgroundTile :type="background.type" :src="background.src" />
+      <BackgroundTile />
       <div class="tile-container">
         <TimeTile />
         <WeatherTile :lat="54.717824" :lng="18.411052" />
@@ -36,17 +36,6 @@
       TimetableTile,
       EmptyTile,
       BackgroundTile,
-    },
-
-    data() {
-      return {
-        background: {
-          type: 'twitch',
-          src: 'esl_csgo'
-          // type: 'image',
-          // src: "http://wp.widewallpapers.net/4k/nature/autumn/3840x2160/autumn-3840x2160-009.jpg",
-        }
-      }
     }
   }
 </script>

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,5 @@
 export const OWM_APPID = process.env.OWM_APPID
 export const API_URL = 'http://localhost:8081/api'
+
+export const BACKGROUND_TYPE = 'twitch'
+export const BACKGROUND_SRC = 'esl_csgo'

--- a/src/tiles/BackgroundTile.vue
+++ b/src/tiles/BackgroundTile.vue
@@ -4,16 +4,19 @@
 </template>
 
 <script>
+    import { BACKGROUND_TYPE, BACKGROUND_SRC } from '../constants'
+
     export default {
-        props: {
-            type: {
-                type: String,
-                required: true,
-            },
-            src: {
-                type: String,
-                required: true,
+        data() {
+            return {
+                type: '',
+                src: ''
             }
+        },
+
+        created() {
+            this.type = BACKGROUND_TYPE
+            this.src = BACKGROUND_SRC
         },
 
         mounted() {


### PR DESCRIPTION
Moved the type and source of the background to constants.js. In this way, it will be easier for the updater to pull changes and keep the same background.

I load the constants in `created()`, but loading them in `data()` works as well. I'm not sure which way is better.